### PR TITLE
Redirect Rust pathway to https://forms.hackclub.com/rust

### DIFF
--- a/resolution-frontend/src/routes/app/+page.svelte
+++ b/resolution-frontend/src/routes/app/+page.svelte
@@ -100,7 +100,9 @@
 							</button>
 						{:else if isSelected}
 							<a
-								href="/app/pathway/{pathway.id.toLowerCase()}"
+								href={pathway.id === 'RUST' ? 'https://forms.hackclub.com/rust' : `/app/pathway/${pathway.id.toLowerCase()}`}
+								target={pathway.id === 'RUST' ? '_blank' : undefined}
+								rel={pathway.id === 'RUST' ? 'noopener noreferrer' : undefined}
 								class="option-card selected"
 							>
 								<img

--- a/resolution-frontend/src/routes/app/pathway/[pathway]/+page.server.ts
+++ b/resolution-frontend/src/routes/app/pathway/[pathway]/+page.server.ts
@@ -23,6 +23,10 @@ export const load: PageServerLoad = async ({ params, parent }) => {
 		throw error(404, 'Pathway not found');
 	}
 
+	if (pathwayId === 'RUST') {
+		throw redirect(302, 'https://forms.hackclub.com/rust');
+	}
+
 	const userPathwayRecord = await db
 		.select()
 		.from(userPathway)

--- a/resolution-frontend/src/routes/app/pathway/[pathway]/week/[week]/+page.server.ts
+++ b/resolution-frontend/src/routes/app/pathway/[pathway]/week/[week]/+page.server.ts
@@ -16,6 +16,10 @@ export const load: PageServerLoad = async ({ params, parent }) => {
 		throw error(404, 'Pathway not found');
 	}
 
+	if (pathwayId === 'RUST') {
+		throw redirect(302, 'https://forms.hackclub.com/rust');
+	}
+
 	if (isNaN(weekNumber) || weekNumber < 1 || weekNumber > 8) {
 		throw error(404, 'Invalid week number');
 	}


### PR DESCRIPTION
Redirects the Rust card and pathway/week pages to the external Rust form.

**Changes:**
- Dashboard Rust card links to `https://forms.hackclub.com/rust` (opens in new tab)
- `/app/pathway/rust` server-side redirects to the form
- `/app/pathway/rust/week/*` server-side redirects to the form