### PR TITLE
fix(build): use dynamic env for CDN API key

### DIFF
--- a/resolution-frontend/src/routes/app/ambassador/[pathway]/week/[week]/+page.server.ts
+++ b/resolution-frontend/src/routes/app/ambassador/[pathway]/week/[week]/+page.server.ts
@@ -3,7 +3,7 @@ import { db } from '$lib/server/db';
 import { ambassadorPathway, pathwayWeekContent } from '$lib/server/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { error, fail } from '@sveltejs/kit';
-import { HACK_CLUB_CDN_API_KEY } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 
 const validPathways = ['PYTHON', 'RUST', 'GAME_DEV', 'HARDWARE', 'DESIGN', 'GENERAL_CODING'] as const;
 type Pathway = typeof validPathways[number];
@@ -167,7 +167,7 @@ export const actions: Actions = {
 		const uploadResponse = await fetch('https://cdn.hackclub.com/api/v4/upload', {
 			method: 'POST',
 			headers: {
-				Authorization: `Bearer ${HACK_CLUB_CDN_API_KEY}`
+				Authorization: `Bearer ${env.HACK_CLUB_CDN_API_KEY}`
 			},
 			body: upstreamForm
 		});


### PR DESCRIPTION
## Summary
- Switches `HACK_CLUB_CDN_API_KEY` from `$env/static/private` to `$env/dynamic/private` so the env var is read at runtime instead of build time
- Fixes the Docker build failure caused by the missing export during `vite build`

## Test plan
- [ ] Verify Docker build completes successfully
- [ ] Verify CDN image upload still works in the ambassador week page