### PR TITLE
fix(build): reapply dynamic env import for CDN API key

### DIFF
--- a/resolution-frontend/src/routes/app/ambassador/[pathway]/week/[week]/+page.server.ts
+++ b/resolution-frontend/src/routes/app/ambassador/[pathway]/week/[week]/+page.server.ts
@@ -3,7 +3,7 @@ import { db } from '$lib/server/db';
 import { ambassadorPathway, pathwayWeekContent } from '$lib/server/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { error, fail } from '@sveltejs/kit';
-import { HACK_CLUB_CDN_API_KEY } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 
 const validPathways = ['PYTHON', 'RUST', 'GAME_DEV', 'HARDWARE', 'DESIGN', 'GENERAL_CODING'] as const;
 type Pathway = typeof validPathways[number];
@@ -167,7 +167,7 @@ export const actions: Actions = {
 		const uploadResponse = await fetch('https://cdn.hackclub.com/api/v4/upload', {
 			method: 'POST',
 			headers: {
-				Authorization: `Bearer ${HACK_CLUB_CDN_API_KEY}`
+				Authorization: `Bearer ${env.HACK_CLUB_CDN_API_KEY}`
 			},
 			body: upstreamForm
 		});


### PR DESCRIPTION
## Summary
- Reverts the revert (#73) to re-apply the `$env/static/private` → `$env/dynamic/private` fix for `HACK_CLUB_CDN_API_KEY`
- The env var must be read at runtime, not build time, since it's not available during Docker build
- Fixes the current deploy failure: `"HACK_CLUB_CDN_API_KEY" is not exported by "\0virtual:env/static/private"`

## Test plan
- [ ] Verify Docker build completes without `HACK_CLUB_CDN_API_KEY` at build time
- [ ] Verify CDN upload works at runtime with the env var set