### PR TITLE
fixed faq section and updated README.md

### DIFF
--- a/resolution-frontend/README.md
+++ b/resolution-frontend/README.md
@@ -1,38 +1,26 @@
-# sv
+# resolution.hackclub.com
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+Choose your challenge and ship every week. Earn prizes each week, and a giant prize if you stay til the end.
 
-## Creating a project
+## Contributing to the site
 
-If you're seeing this, you've probably already done this step. Congrats!
-
-```sh
-# create a new project in the current directory
-npx sv create
-
-# create a new project in my-app
-npx sv create my-app
-```
-
-## Developing
-
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+1. Create your own fork of this repo (by clicking the fork button)
+2. Now copy the url to your forked repo and clone it using :
 
 ```sh
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
+git clone https://github.com/your_username_here/resolution
+cd resolution/resolution-frontend
 ```
 
-## Building
-
-To create a production version of your app:
+3. now install npm packages 
 
 ```sh
-npm run build
+# shorthand for : bun install
+bun i
+
+# or if you have npm. 
+npm i
 ```
 
-You can preview the production build with `npm run preview`.
+4. start coding and make your PR, yayay !
 
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.

--- a/resolution-frontend/README.md
+++ b/resolution-frontend/README.md
@@ -1,6 +1,6 @@
 # resolution.hackclub.com
 
-Choose your challenge and ship every week. Earn prizes each week, and a giant prize if you stay til the end.
+Choose your challenge and ship every week. Earn prizes each week, and a giant prize if you stay until the end.
 
 ## Contributing to the site
 

--- a/resolution-frontend/src/lib/components/InitialPage.svelte
+++ b/resolution-frontend/src/lib/components/InitialPage.svelte
@@ -474,7 +474,7 @@
 
 	.faq-divider {
 		width: 100%;
-		height: auto;
+		height: 1px;
 		display: block;
 		opacity: 0.8;
 	}


### PR DESCRIPTION
i fixed the faq section's frontend by replacing `height: auto;` to `height: 1px;` 

How it was looking before
<img width="1474" height="1156" alt="image" src="https://github.com/user-attachments/assets/9600bd3a-b387-4901-96ee-7dcddeb8bfe6" />

how is it looking after this commit 
<img width="2000" height="1084" alt="image" src="https://github.com/user-attachments/assets/a906acb7-d799-4f90-b5ae-ff01582eadac" />


I updated the default svelte README.md to have a mini contribution guide and a slogan for resolution.hackclub.com. 

> This is my first commit in hackclub's github. so i am really sorry if i made a mistake or did something bad here. thank you so much for running and maintaining resolution. 